### PR TITLE
Set cache request to every 15min.

### DIFF
--- a/ansible/roles/flask/tasks/main.yml
+++ b/ansible/roles/flask/tasks/main.yml
@@ -59,7 +59,6 @@
   become: yes
   cron:
     name: "Cache datasets endpoint"
-    minute: 0
-    hour: "*/6"
+    minute: */15
     job: "wget -O /dev/null -o /dev/null http://{{ server_name }}/api/datasets"
   when: not vagrant


### PR DESCRIPTION
The dataset cache runs for 6 hours after rollout. Then it needs to be recomputed, which will happen within 15min.

Ideally the cache doesn't timeout after 6 hours, but can be reset based on the "done" event in GEE and be rebuilt in the backend.
