### PR TITLE
Changing mapbox layers from GTSMv2 to GTSMv4 output locations, adding SPI dataset

### DIFF
--- a/dgds_backend/stac/current/collection.json
+++ b/dgds_backend/stac/current/collection.json
@@ -160,9 +160,9 @@
         },
         {
             "rel": "child",
-            "href": "https://blueearthdata.org/api/static_stac/globcover/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/collection.json",
             "type": "application/json",
-            "title": "globcover"
+            "title": "crucial_spi6"
         },
         {
             "rel": "self",

--- a/dgds_backend/stac/current/crucial_spi6/collection.json
+++ b/dgds_backend/stac/current/crucial_spi6/collection.json
@@ -1,0 +1,71 @@
+{
+    "id": "crucial_spi6",
+    "stac_version": "1.0.0-beta.2",
+    "description": "The standardized precipitation index (SPI) is a probability based indicator for abnormal wetness and dryness (McKee et al., 1993; McKee et al., 1995). The SPI can be applied for different time scales of precipitation (usually 1 - 24 months). The first step in calculating the SPI is to determine a probability density function that describes the long-term time series of precipitation observations. Once the probability density function is determined, the cumulative probability of an observed precipitation amount is computed. The inverse normal (Gaussian) function, with mean zero and variance one, is then applied to the cumulative probability. The result are the SPI-timeseries that were calculated over the period 1998-2018 from the ERA5 dataset (Hersbach et al., 2020) from ECMWF.</br></br>The implementation used in this project is based on (Adams, 2017): https://github.com/monocongo/climate_indices</br></br>Adams, J. 2017. Climate_indices, an open source Python library providing reference implementations of commonly used climate indices, url    = https://github.com/monocongo/climate_indices</br>Hersbach, H. et al. 2020. The ERA5 Global Reanalysis. Quarterly Journal of the Royal Meteorological Society, doi: 10.1002/qj.3803.</br>McKee, T. B, N. J. Doeskin, and J. Kieist, 1993. The Relationship of Drought Frequency and Duration to Time Scales. Proc. 8th Conf. on Applied Climatology, January 17-22, 1993, American Meteorological Society, Boston, Massachusetts, pp. 179-184.</br>McKee, T. B, N. J. Doeskin, and J. Kieist, 1995. Drought Monitoring with Multiple Time Scales. Proc. 9th Conf. on Applied Climatology, January 15-20, 1995",
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "child",
+            "href": "http://127.0.0.1:5000/stac/crucial_spi6-gee",
+            "type": "application/json",
+            "title": "crucial_spi6-gee"
+        },
+        {
+            "rel": "self",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "title": "Standardized precipitation index",
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180.0,
+                    -90.0,
+                    180.0,
+                    90.0
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2015-10-22T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "proprietary",
+    "license_use": "Groundwater declining trend and Evaporation deficit (CRUCIAL) Data. - The Groundwater declining trend and Evaporation deficit (CRUCIAL) data are provided to give User a merely indicative first view of groundwater changes and the evapodation deficit at a location or area of User’s choice. It is noted the global data sources used are generally of rather coarse spatial resolution and dedicated local studies may be needed for more detailed output. - The Groundwater declining trend and Evaporation deficit (CRUCIAL) data should be considered as indicative data, which were validated to a limited extent. User hereby agrees NOT to use the Groundwater declining trend and Evaporation deficit (CRUCIAL) data products for any official reporting, decision-making or operational purposes.",
+    "license_warranty": "Groundwater declining trend and Evaporation deficit (CRUCIAL) Products: Deltares does not guarantee, or imply in any way, that the Groundwater declining trend and Evaporation deficit (CRUCIAL) will correspond to actual groundwater changes and evaporation deficits at User’s selected area(s) and timeframe(s).",
+    "keywords": [
+        "Water availability"
+    ],
+    "providers": [
+        {
+            "name": "Deltares",
+            "description": "Deltares is an independent institute for applied research in the field of water and subsurface.",
+            "roles": [
+                "producer",
+                "processor"
+            ],
+            "url": "https://www.deltares.nl"
+        }
+    ],
+    "properties": {
+        "deltares:scope": "global",
+        "deltares:timeSpan": "Live",
+        "deltares:units": "%"
+    }
+}

--- a/dgds_backend/stac/current/crucial_spi6/crucial_spi6-gee/collection.json
+++ b/dgds_backend/stac/current/crucial_spi6/crucial_spi6-gee/collection.json
@@ -1,0 +1,95 @@
+{
+    "id": "crucial_spi6-gee",
+    "stac_version": "1.0.0-beta.2",
+    "description": "The standardized precipitation index (SPI) is a probability based indicator for abnormal wetness and dryness (McKee et al., 1993; McKee et al., 1995). The SPI can be applied for different time scales of precipitation (usually 1 - 24 months). The first step in calculating the SPI is to determine a probability density function that describes the long-term time series of precipitation observations. Once the probability density function is determined, the cumulative probability of an observed precipitation amount is computed. The inverse normal (Gaussian) function, with mean zero and variance one, is then applied to the cumulative probability. The result are the SPI-timeseries that were calculated over the period 1998-2018 from the ERA5 dataset (Hersbach et al., 2020) from ECMWF.</br></br>The implementation used in this project is based on (Adams, 2017): https://github.com/monocongo/climate_indices</br></br>Adams, J. 2017. Climate_indices, an open source Python library providing reference implementations of commonly used climate indices, url    = https://github.com/monocongo/climate_indices</br>Hersbach, H. et al. 2020. The ERA5 Global Reanalysis. Quarterly Journal of the Royal Meteorological Society, doi: 10.1002/qj.3803.</br>McKee, T. B, N. J. Doeskin, and J. Kieist, 1993. The Relationship of Drought Frequency and Duration to Time Scales. Proc. 8th Conf. on Applied Climatology, January 17-22, 1993, American Meteorological Society, Boston, Massachusetts, pp. 179-184.</br>McKee, T. B, N. J. Doeskin, and J. Kieist, 1995. Drought Monitoring with Multiple Time Scales. Proc. 9th Conf. on Applied Climatology, January 15-20, 1995",
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "item",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/crucial_spi6-gee/crucial_spi6-gee-SPI6_19890131000000/crucial_spi6-gee-SPI6_19890131000000.json",
+            "type": "application/json",
+            "title": "crucial_spi6-gee-evaporation_deficit_19890131000000"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "featureinfo": {
+            "href": "http://127.0.0.1:8080/get_feature_info",
+            "type": "application/json",
+            "title": "FeatureInfo",
+            "description": "FeatureInfo",
+            "name": "SPI6",
+            "roles": [
+                "featureinfo"
+            ]
+        }
+    },
+    "summaries": {
+        "eo:bands": [
+            {
+                "band": "b1",
+                "name": "b1",
+                "description": "SPI6",
+                "min": -4.0,
+                "max": 4.0,
+                "palette": [
+                    "#6e1c05",
+                    "#902F14",
+                    "#FFFFFF",
+                    "#006391",
+                    "#023e59"
+                ],
+               "imageCollection_id": "projects/dgds-gee/crucial/SPI6"
+            }
+        ]
+    },
+    "title": "SPI6",
+    "extent": {
+        "spatial": {
+            "bbox": [
+                [
+                    -180.0,
+                    -90.0,
+                    180.0,
+                    90.0
+                ]
+            ]
+        },
+        "temporal": {
+            "interval": [
+                [
+                    "2015-10-22T00:00:00Z",
+                    null
+                ]
+            ]
+        }
+    },
+    "license": "proprietary",
+    "keywords": [
+        "Water availability"
+    ],
+    "providers": [
+        {
+            "name": "Deltares",
+            "description": "Deltares is an independent institute for applied research in the field of water and subsurface.",
+            "roles": [
+                "producer",
+                "processor"
+            ],
+            "url": "https://www.deltares.nl"
+        }
+    ],
+    "properties": {
+        "deltares:name": "projects/dgds-gee/crucial/SPI6",
+        "deltares:parameters": {},
+        "deltares:url": "http://127.0.0.1:8080/get_stac_collection"
+    }
+}

--- a/dgds_backend/stac/current/crucial_spi6/crucial_spi6-gee/crucial_spi6-gee-SPI6_19890131000000/crucial_spi6-gee-SPI6_19890131000000.json
+++ b/dgds_backend/stac/current/crucial_spi6/crucial_spi6-gee/crucial_spi6-gee-SPI6_19890131000000/crucial_spi6-gee-SPI6_19890131000000.json
@@ -1,0 +1,108 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "crucial_spi6-gee-SPI6_19890131000000",
+    "properties": {
+        "deltares:min": -4,
+        "deltares:max": 4,
+        "deltares:palette": [
+            "#902F14",
+            "#343332",
+            "#006391"
+        ],
+        "deltares:band": "b1",
+        "deltares:linearGradient": [
+            {
+                "offset": "0.000%",
+                "opacity": 100,
+                "color": "#902F14"
+            },
+            {
+                "offset": "50.000%",
+                "opacity": 100,
+                "color": "#343332"
+            },
+            {
+                "offset": "100.000%",
+                "opacity": 100,
+                "color": "#006391"
+            }
+        ],
+        "deltares:source": "projects/dgds-gee/crucial/SPI6",
+        "deltares:date": "1989-01-31T00:00:00",
+        "deltares:imageId": "projects/dgds-gee/crucial/SPI6/SPI6_19890131000000",
+        "deltares:dataset": "SPI6",
+        "datetime": "1989-01-31T00:00:00Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    -90.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/crucial_spi6-gee/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/crucial_spi6-gee/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/crucial_spi6/crucial_spi6-gee/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "visual": {
+            "href": "https://earthengine.googleapis.com/v1alpha/projects/earthengine-legacy/maps/cab69f3e9c21627e21ecaed2cef60b2b-373108eb1195c3c030a00919aaecabe2/tiles/{z}/{x}/{y}",
+            "type": "application/png",
+            "title": "GEE",
+            "description": "GEE WMS url",
+            "roles": [
+                "visual"
+            ]
+        },
+        "data": {
+            "href": "gs://dgds-data/crucial/spi6",
+            "type": "application/geotiff",
+            "title": "COG",
+            "description": "Google Bucket COG",
+            "roles": [
+                "data"
+            ]
+        }
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "collection": "crucial_spi6-gee"
+}

--- a/dgds_backend/stac/current/sh/sh-mapbox/collection.json
+++ b/dgds_backend/stac/current/sh/sh-mapbox/collection.json
@@ -10,9 +10,15 @@
         },
         {
             "rel": "item",
-            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/sh-mapbox-glossis/sh-mapbox-glossis.json",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/sh-mapbox-glossis-z0/sh-mapbox-glossis-z0.json",
             "type": "application/json",
-            "title": "sh-mapbox-glossis"
+            "title": "sh-mapbox-glossis-z0"
+        },
+        {
+            "rel": "item",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/sh-mapbox-glossis-z3/sh-mapbox-glossis-z3.json",
+            "type": "application/json",
+            "title": "sh-mapbox-glossis-z3"
         },
         {
             "rel": "parent",

--- a/dgds_backend/stac/current/sh/sh-mapbox/sh-mapbox-glossis-z0/sh-mapbox-glossis-z0.json
+++ b/dgds_backend/stac/current/sh/sh-mapbox/sh-mapbox-glossis-z0/sh-mapbox-glossis-z0.json
@@ -1,0 +1,84 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "sh-mapbox-glossis-z0",
+    "properties": {
+        "deltares:id": "GLOSSIS_z0",
+        "deltares:filterIds": [
+            "H.surge.simulated"
+        ],
+        "deltares:type": "circle",
+        "deltares:source": {
+            "url": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector"
+        },
+        "deltares:source-layer": "glossis_gtsmv41_sparse_factor-0xcsqh",
+        "deltares:maxzoom": 3,
+        "deltares:onClick": {
+            "method": "showGraph"
+        },
+        "datetime": "2021-04-23T14:48:13.036524Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    -90.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "mapbox": {
+            "href": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector",
+            "title": "Mapbox",
+            "description": "Mapbox url",
+            "roles": [
+                "mapbox"
+            ]
+        }
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "collection": "sh-mapbox"
+}

--- a/dgds_backend/stac/current/sh/sh-mapbox/sh-mapbox-glossis-z3/sh-mapbox-glossis-z3.json
+++ b/dgds_backend/stac/current/sh/sh-mapbox/sh-mapbox-glossis-z3/sh-mapbox-glossis-z3.json
@@ -1,22 +1,23 @@
 {
     "type": "Feature",
     "stac_version": "1.0.0-beta.2",
-    "id": "wl-mapbox-glossis",
+    "id": "sh-mapbox-glossis-z3",
     "properties": {
-        "deltares:id": "GLOSSIS",
+        "deltares:id": "GLOSSIS_z3",
         "deltares:filterIds": [
-            "H.simulated"
+            "H.surge.simulated"
         ],
         "deltares:type": "circle",
         "deltares:source": {
-            "type": "vector",
-            "url": "mapbox://global-data-viewer.9bzmgyig"
+            "url": "mapbox://global-data-viewer.8oojzt58",
+            "type": "vector"
         },
-        "deltares:source-layer": "glossis_gtsmv41-895ppt",
+        "deltares:source-layer": "glossis_gtsmv41-70mzoj",
+        "deltares:minzoom": 3,
         "deltares:onClick": {
             "method": "showGraph"
         },
-        "datetime": "2021-04-23T14:48:10.403984Z"
+        "datetime": "2021-04-23T14:48:13.036524Z"
     },
     "geometry": {
         "type": "Polygon",
@@ -48,23 +49,23 @@
     "links": [
         {
             "rel": "root",
-            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "collection",
-            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "parent",
-            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
             "type": "application/json"
         }
     ],
     "assets": {
         "mapbox": {
-            "href": "mapbox://global-data-viewer.9bzmgyig",
+            "href": "mapbox://global-data-viewer.8oojzt58",
             "type": "vector",
             "title": "Mapbox",
             "description": "Mapbox url",
@@ -79,5 +80,5 @@
         180,
         90
     ],
-    "collection": "wl-mapbox"
+    "collection": "sh-mapbox"
 }

--- a/dgds_backend/stac/current/tt/tt-mapbox/collection.json
+++ b/dgds_backend/stac/current/tt/tt-mapbox/collection.json
@@ -10,9 +10,15 @@
         },
         {
             "rel": "item",
-            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/tt-mapbox-glossis/tt-mapbox-glossis.json",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/tt-mapbox-glossis-z0/tt-mapbox-glossis-z0.json",
             "type": "application/json",
-            "title": "tt-mapbox-glossis"
+            "title": "tt-mapbox-glossis-z0"
+        },
+        {
+            "rel": "item",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/tt-mapbox-glossis-z3/tt-mapbox-glossis-z3.json",
+            "type": "application/json",
+            "title": "tt-mapbox-glossis-z3"
         },
         {
             "rel": "parent",

--- a/dgds_backend/stac/current/tt/tt-mapbox/tt-mapbox-glossis-z0/tt-mapbox-glossis-z0.json
+++ b/dgds_backend/stac/current/tt/tt-mapbox/tt-mapbox-glossis-z0/tt-mapbox-glossis-z0.json
@@ -1,0 +1,84 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "tt-mapbox-glossis-z0",
+    "properties": {
+        "deltares:id": "GLOSSIS_z0",
+        "deltares:filterIds": [
+            "H.astronomical.simulated"
+        ],
+        "deltares:type": "circle",
+        "deltares:source": {
+            "url": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector"
+        },
+        "deltares:source-layer": "glossis_gtsmv41_sparse_factor-0xcsqh",
+        "deltares:maxzoom": 3,
+        "deltares:onClick": {
+            "method": "showGraph"
+        },
+        "datetime": "2021-04-23T14:48:15.928861Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    -90.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "mapbox": {
+            "href": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector",
+            "title": "Mapbox",
+            "description": "Mapbox url",
+            "roles": [
+                "mapbox"
+            ]
+        }
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "collection": "tt-mapbox"
+}

--- a/dgds_backend/stac/current/tt/tt-mapbox/tt-mapbox-glossis-z3/tt-mapbox-glossis-z3.json
+++ b/dgds_backend/stac/current/tt/tt-mapbox/tt-mapbox-glossis-z3/tt-mapbox-glossis-z3.json
@@ -1,23 +1,23 @@
 {
     "type": "Feature",
     "stac_version": "1.0.0-beta.2",
-    "id": "wd-mapbox-glossis",
+    "id": "tt-mapbox-glossis-z3",
     "properties": {
-        "deltares:id": "GLOSSIS",
+        "deltares:id": "GLOSSIS_z3",
         "deltares:filterIds": [
-            "Wind.speed",
-            "Wind.direction"
+            "H.astronomical.simulated"
         ],
         "deltares:type": "circle",
         "deltares:source": {
-            "type": "vector",
-            "url": "mapbox://global-data-viewer.6w19mbaw"
+            "url": "mapbox://global-data-viewer.8oojzt58",
+            "type": "vector"
         },
-        "deltares:source-layer": "pltc012flat",
+        "deltares:source-layer": "glossis_gtsmv41-70mzoj",
+        "deltares:minzoom": 3,
         "deltares:onClick": {
             "method": "showGraph"
         },
-        "datetime": "2021-04-23T14:48:21.190404Z"
+        "datetime": "2021-04-23T14:48:15.928861Z"
     },
     "geometry": {
         "type": "Polygon",
@@ -49,23 +49,23 @@
     "links": [
         {
             "rel": "root",
-            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "collection",
-            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "parent",
-            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
             "type": "application/json"
         }
     ],
     "assets": {
         "mapbox": {
-            "href": "mapbox://global-data-viewer.6w19mbaw",
+            "href": "mapbox://global-data-viewer.8oojzt58",
             "type": "vector",
             "title": "Mapbox",
             "description": "Mapbox url",
@@ -80,5 +80,5 @@
         180,
         90
     ],
-    "collection": "wd-mapbox"
+    "collection": "tt-mapbox"
 }

--- a/dgds_backend/stac/current/wd/wd-mapbox/collection.json
+++ b/dgds_backend/stac/current/wd/wd-mapbox/collection.json
@@ -10,9 +10,15 @@
         },
         {
             "rel": "item",
-            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/wd-mapbox-glossis/wd-mapbox-glossis.json",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/wd-mapbox-glossis-z0/wd-mapbox-glossis-z0.json",
             "type": "application/json",
-            "title": "wd-mapbox-glossis"
+            "title": "wd-mapbox-glossis-z0"
+        },
+        {
+            "rel": "item",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/wd-mapbox-glossis-z3/wd-mapbox-glossis-z3.json",
+            "type": "application/json",
+            "title": "wd-mapbox-glossis-z3"
         },
         {
             "rel": "parent",
@@ -31,7 +37,7 @@
             ]
         },
         "timeseries": {
-            "href": "http://c-fews0169.directory.intra:8080/FewsWebServices/rest/digitaledelta/2.0",
+            "href": "http://c-fews0468.directory.intra:8080/FewsWebServices/rest/digitaledelta/2.0",
             "type": "dd-api",
             "title": "GLOSSIS Delft-FEWS DD API endpoint",
             "description": "Timeseries endpoint",

--- a/dgds_backend/stac/current/wd/wd-mapbox/wd-mapbox-glossis-z0/wd-mapbox-glossis-z0.json
+++ b/dgds_backend/stac/current/wd/wd-mapbox/wd-mapbox-glossis-z0/wd-mapbox-glossis-z0.json
@@ -1,22 +1,24 @@
 {
     "type": "Feature",
     "stac_version": "1.0.0-beta.2",
-    "id": "wv-mapbox-glossis",
+    "id": "wd-mapbox-glossis-z0",
     "properties": {
-        "deltares:id": "GLOSSIS",
+        "deltares:id": "GLOSSIS_z0",
         "deltares:filterIds": [
-            "H.simulated"
+            "Wind.speed",
+            "Wind.direction"
         ],
         "deltares:type": "circle",
         "deltares:source": {
-            "type": "vector",
-            "url": "mapbox://global-data-viewer.6w19mbaw"
+            "url": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector"
         },
-        "deltares:source-layer": "pltc012flat",
+        "deltares:source-layer": "glossis_gtsmv41_sparse_factor-0xcsqh",
+        "deltares:maxzoom": 3,
         "deltares:onClick": {
             "method": "showGraph"
         },
-        "datetime": "2021-04-23T14:48:23.629738Z"
+        "datetime": "2021-04-23T14:48:21.190404Z"
     },
     "geometry": {
         "type": "Polygon",
@@ -48,23 +50,23 @@
     "links": [
         {
             "rel": "root",
-            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "collection",
-            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "parent",
-            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
             "type": "application/json"
         }
     ],
     "assets": {
         "mapbox": {
-            "href": "mapbox://global-data-viewer.6w19mbaw",
+            "href": "mapbox://global-data-viewer.2cnswteu",
             "type": "vector",
             "title": "Mapbox",
             "description": "Mapbox url",
@@ -79,5 +81,5 @@
         180,
         90
     ],
-    "collection": "wv-mapbox"
+    "collection": "wd-mapbox"
 }

--- a/dgds_backend/stac/current/wd/wd-mapbox/wd-mapbox-glossis-z3/wd-mapbox-glossis-z3.json
+++ b/dgds_backend/stac/current/wd/wd-mapbox/wd-mapbox-glossis-z3/wd-mapbox-glossis-z3.json
@@ -1,22 +1,24 @@
 {
     "type": "Feature",
     "stac_version": "1.0.0-beta.2",
-    "id": "sh-mapbox-glossis",
+    "id": "wd-mapbox-glossis-z3",
     "properties": {
-        "deltares:id": "GLOSSIS",
+        "deltares:id": "GLOSSIS_z3",
         "deltares:filterIds": [
-            "H.surge.simulated"
+            "Wind.speed",
+            "Wind.direction"
         ],
         "deltares:type": "circle",
         "deltares:source": {
-            "type": "vector",
-            "url": "mapbox://global-data-viewer.9bzmgyig"
+            "url": "mapbox://global-data-viewer.8oojzt58",
+            "type": "vector"
         },
-        "deltares:source-layer": "glossis_gtsmv41-895ppt",
+        "deltares:source-layer": "glossis_gtsmv41-70mzoj",
+        "deltares:minzoom": 3,
         "deltares:onClick": {
             "method": "showGraph"
         },
-        "datetime": "2021-04-23T14:48:13.036524Z"
+        "datetime": "2021-04-23T14:48:21.190404Z"
     },
     "geometry": {
         "type": "Polygon",
@@ -48,23 +50,23 @@
     "links": [
         {
             "rel": "root",
-            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "collection",
-            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "parent",
-            "href": "https://blueearthdata.org/api/static_stac/sh/sh-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wd/wd-mapbox/collection.json",
             "type": "application/json"
         }
     ],
     "assets": {
         "mapbox": {
-            "href": "mapbox://global-data-viewer.9bzmgyig",
+            "href": "mapbox://global-data-viewer.8oojzt58",
             "type": "vector",
             "title": "Mapbox",
             "description": "Mapbox url",
@@ -79,5 +81,5 @@
         180,
         90
     ],
-    "collection": "sh-mapbox"
+    "collection": "wd-mapbox"
 }

--- a/dgds_backend/stac/current/wl/wl-mapbox/collection.json
+++ b/dgds_backend/stac/current/wl/wl-mapbox/collection.json
@@ -10,9 +10,15 @@
         },
         {
             "rel": "item",
-            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/wl-mapbox-glossis/wl-mapbox-glossis.json",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/wl-mapbox-glossis-z0/wl-mapbox-glossis-z0.json",
             "type": "application/json",
-            "title": "wl-mapbox-glossis"
+            "title": "wl-mapbox-glossis-z0"
+        },
+        {
+            "rel": "item",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/wl-mapbox-glossis-z3/wl-mapbox-glossis-z3.json",
+            "type": "application/json",
+            "title": "wl-mapbox-glossis-z3"
         },
         {
             "rel": "parent",

--- a/dgds_backend/stac/current/wl/wl-mapbox/wl-mapbox-glossis-z0/wl-mapbox-glossis-z0.json
+++ b/dgds_backend/stac/current/wl/wl-mapbox/wl-mapbox-glossis-z0/wl-mapbox-glossis-z0.json
@@ -1,0 +1,84 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "wl-mapbox-glossis-z0",
+    "properties": {
+        "deltares:id": "GLOSSIS_z0",
+        "deltares:filterIds": [
+            "H.simulated"
+        ],
+        "deltares:type": "circle",
+        "deltares:source": {
+            "url": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector"
+        },
+        "deltares:source-layer": "glossis_gtsmv41_sparse_factor-0xcsqh",
+        "deltares:maxzoom": 3,
+        "deltares:onClick": {
+            "method": "showGraph"
+        },
+        "datetime": "2021-04-23T14:48:10.403984Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    -90.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "mapbox": {
+            "href": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector",
+            "title": "Mapbox",
+            "description": "Mapbox url",
+            "roles": [
+                "mapbox"
+            ]
+        }
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "collection": "wl-mapbox"
+}

--- a/dgds_backend/stac/current/wl/wl-mapbox/wl-mapbox-glossis-z3/wl-mapbox-glossis-z3.json
+++ b/dgds_backend/stac/current/wl/wl-mapbox/wl-mapbox-glossis-z3/wl-mapbox-glossis-z3.json
@@ -1,0 +1,84 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "wl-mapbox-glossis-z3",
+    "properties": {
+        "deltares:id": "GLOSSIS_z3",
+        "deltares:filterIds": [
+            "H.simulated"
+        ],
+        "deltares:type": "circle",
+        "deltares:source": {
+            "url": "mapbox://global-data-viewer.8oojzt58",
+            "type": "vector"
+        },
+        "deltares:source-layer": "glossis_gtsmv41-70mzoj",
+        "deltares:minzoom": 3,
+        "deltares:onClick": {
+            "method": "showGraph"
+        },
+        "datetime": "2021-04-23T14:48:10.403984Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    -90.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/wl/wl-mapbox/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "mapbox": {
+            "href": "mapbox://global-data-viewer.8oojzt58",
+            "type": "vector",
+            "title": "Mapbox",
+            "description": "Mapbox url",
+            "roles": [
+                "mapbox"
+            ]
+        }
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "collection": "wl-mapbox"
+}

--- a/dgds_backend/stac/current/wv/wv-mapbox/collection.json
+++ b/dgds_backend/stac/current/wv/wv-mapbox/collection.json
@@ -10,9 +10,15 @@
         },
         {
             "rel": "item",
-            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/wv-mapbox-glossis/wv-mapbox-glossis.json",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/wv-mapbox-glossis-z0/wv-mapbox-glossis-z0.json",
             "type": "application/json",
-            "title": "wv-mapbox-glossis"
+            "title": "wv-mapbox-glossis-z0"
+        },
+        {
+            "rel": "item",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/wv-mapbox-glossis-z3/wv-mapbox-glossis-z3.json",
+            "type": "application/json",
+            "title": "wv-mapbox-glossis-z3"
         },
         {
             "rel": "parent",
@@ -31,7 +37,7 @@
             ]
         },
         "timeseries": {
-            "href": "http://c-fews0169.directory.intra:8080/FewsWebServices/rest/digitaledelta/2.0",
+            "href": "http://c-fews0468.directory.intra:8080/FewsWebServices/rest/digitaledelta/2.0",
             "type": "dd-api",
             "title": "GLOSSIS Delft-FEWS DD API endpoint",
             "description": "Timeseries endpoint",

--- a/dgds_backend/stac/current/wv/wv-mapbox/wv-mapbox-glossis-z0/wv-mapbox-glossis-z0.json
+++ b/dgds_backend/stac/current/wv/wv-mapbox/wv-mapbox-glossis-z0/wv-mapbox-glossis-z0.json
@@ -1,0 +1,84 @@
+{
+    "type": "Feature",
+    "stac_version": "1.0.0-beta.2",
+    "id": "wv-mapbox-glossis-z0",
+    "properties": {
+        "deltares:id": "GLOSSIS_z0",
+        "deltares:filterIds": [
+            "H.simulated"
+        ],
+        "deltares:type": "circle",
+        "deltares:source": {
+            "url": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector"
+        },
+        "deltares:source-layer": "glossis_gtsmv41_sparse_factor-0xcsqh",
+        "deltares:maxzoom": 3,
+        "deltares:onClick": {
+            "method": "showGraph"
+        },
+        "datetime": "2021-04-23T14:48:23.629738Z"
+    },
+    "geometry": {
+        "type": "Polygon",
+        "coordinates": [
+            [
+                [
+                    -180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    -90.0
+                ],
+                [
+                    180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    90.0
+                ],
+                [
+                    -180.0,
+                    -90.0
+                ]
+            ]
+        ]
+    },
+    "links": [
+        {
+            "rel": "root",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "collection",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
+            "type": "application/json"
+        },
+        {
+            "rel": "parent",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
+            "type": "application/json"
+        }
+    ],
+    "assets": {
+        "mapbox": {
+            "href": "mapbox://global-data-viewer.2cnswteu",
+            "type": "vector",
+            "title": "Mapbox",
+            "description": "Mapbox url",
+            "roles": [
+                "mapbox"
+            ]
+        }
+    },
+    "bbox": [
+        -180,
+        -90,
+        180,
+        90
+    ],
+    "collection": "wv-mapbox"
+}

--- a/dgds_backend/stac/current/wv/wv-mapbox/wv-mapbox-glossis-z3/wv-mapbox-glossis-z3.json
+++ b/dgds_backend/stac/current/wv/wv-mapbox/wv-mapbox-glossis-z3/wv-mapbox-glossis-z3.json
@@ -1,22 +1,23 @@
 {
     "type": "Feature",
     "stac_version": "1.0.0-beta.2",
-    "id": "tt-mapbox-glossis",
+    "id": "wl-mapbox-glossis-z3",
     "properties": {
-        "deltares:id": "GLOSSIS",
+        "deltares:id": "GLOSSIS_z3",
         "deltares:filterIds": [
-            "H.astronomical.simulated"
+            "H.simulated"
         ],
         "deltares:type": "circle",
         "deltares:source": {
-            "type": "vector",
-            "url": "mapbox://global-data-viewer.9bzmgyig"
+            "url": "mapbox://global-data-viewer.8oojzt58",
+            "type": "vector"
         },
-        "deltares:source-layer": "glossis_gtsmv41-895ppt",
+        "deltares:source-layer": "glossis_gtsmv41-70mzoj",
+        "deltares:minzoom": 3,
         "deltares:onClick": {
             "method": "showGraph"
         },
-        "datetime": "2021-04-23T14:48:15.928861Z"
+        "datetime": "2021-04-23T14:48:23.629738Z"
     },
     "geometry": {
         "type": "Polygon",
@@ -48,23 +49,23 @@
     "links": [
         {
             "rel": "root",
-            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "collection",
-            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
             "type": "application/json"
         },
         {
             "rel": "parent",
-            "href": "https://blueearthdata.org/api/static_stac/tt/tt-mapbox/collection.json",
+            "href": "https://blueearthdata.org/api/static_stac/wv/wv-mapbox/collection.json",
             "type": "application/json"
         }
     ],
     "assets": {
         "mapbox": {
-            "href": "mapbox://global-data-viewer.9bzmgyig",
+            "href": "mapbox://global-data-viewer.8oojzt58",
             "type": "vector",
             "title": "Mapbox",
             "description": "Mapbox url",
@@ -79,5 +80,5 @@
         180,
         90
     ],
-    "collection": "tt-mapbox"
+    "collection": "wv-mapbox"
 }


### PR DESCRIPTION
Changes:
1. The output locations for GTSMv4.1 are different from those in GTSMv2. As such, a different mapbox layer is required if we want to switch to GTSMv4.1 in BlueEarth Data (for datasets water level, tide, currents, wind and waves). Given the number of points, different mapbox layers are required at different zoom levels (the layer with all points does not show at Z0-Z2 zoom levels). Hence, there are now two layers, with differences in the points shown, to resolve this. Also, for some of the datasets, we were still referring to the web services of the GLOSSIS test system. Changes this to the web services for the GLOSSIS production system.
Once this change is deployed in the back-end, will still need to deploy a small change to GLOSSIS to connect to the correct data. And, will change the feed of raster data to GEE from the old to the new model. This does not require changes on the side of BED, though.
2. Added SPI data from CRUCIAL project.

